### PR TITLE
Authorize export requests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,6 +24,7 @@ module.exports = {
         '@typescript-eslint/no-useless-constructor': 'error',
         'no-empty-function': 'off',
         '@typescript-eslint/no-empty-function': 'error',
+        "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.ts"]}]
     },
     settings: {
         'import/resolver': {

--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
   },
   "dependencies": {
     "fhir-works-on-aws-interface": "^1.0.0",
-    "jsonwebtoken": "^8.5.1"
+    "jsonwebtoken": "^8.5.1",
+    "lodash": "^4.17.20"
   },
   "devDependencies": {
     "@types/jest": "^25.1.1",
     "@types/jsonwebtoken": "^8.5.0",
+    "@types/lodash": "^4.14.161",
     "@types/node": "^12",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/jsonwebtoken": "^8.5.0",
     "@types/lodash": "^4.14.161",
     "@types/node": "^12",
+    "@types/shuffle-array": "^1.0.0",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
     "eslint": "^6.8.0",
@@ -47,6 +48,7 @@
     "jest": "^25.1.0",
     "jest-mock-extended": "^1.0.8",
     "prettier": "^1.19.1",
+    "shuffle-array": "^1.0.1",
     "ts-jest": "^25.1.0",
     "typescript": "^3.7.5"
   },

--- a/src/RBACConfig.ts
+++ b/src/RBACConfig.ts
@@ -14,6 +14,6 @@ export interface GroupRule {
     [groupName: string]: Rule;
 }
 export interface Rule {
-    operations: (TypeOperation | SystemOperation | 'export')[];
+    operations: (TypeOperation | SystemOperation)[];
     resources: string[]; // This will be able to support any type of resource
 }

--- a/src/RBACConfig.ts
+++ b/src/RBACConfig.ts
@@ -14,6 +14,6 @@ export interface GroupRule {
     [groupName: string]: Rule;
 }
 export interface Rule {
-    operations: (TypeOperation | SystemOperation)[];
+    operations: (TypeOperation | SystemOperation | 'export')[];
     resources: string[]; // This will be able to support any type of resource
 }

--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -11,7 +11,6 @@ import {
     FhirVersion,
     BASE_STU3_RESOURCES,
 } from 'fhir-works-on-aws-interface';
-// eslint-disable-next-line import/no-extraneous-dependencies
 import shuffle from 'shuffle-array';
 import { RBACHandler } from './RBACHandler';
 import { RBACConfig } from './RBACConfig';

--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -193,11 +193,19 @@ describe('isAuthorized:Export', () => {
         version: 1.0,
         groupRules: {
             practitioner: {
-                operations: ['create', 'read', 'update', 'delete', 'vread', 'search-type', 'transaction'],
+                operations: ['read'],
                 resources: [],
             },
         },
     };
+
+    afterEach(() => {
+        customRBACRules.groupRules.practitioner = {
+            operations: ['read'],
+            resources: [],
+        };
+    });
+
     test('TRUE; GET system Export with permission to all resources', async () => {
         customRBACRules.groupRules.practitioner.resources = SUPPORTED_R4_RESOURCES;
         const authZHandler: RBACHandler = new RBACHandler(customRBACRules, '4.0.1');
@@ -222,6 +230,18 @@ describe('isAuthorized:Export', () => {
 
     test('FALSE; GET system Export without permission to all resources', async () => {
         customRBACRules.groupRules.practitioner.resources = ['Patient', 'MedicationRequest'];
+        const authZHandler: RBACHandler = new RBACHandler(customRBACRules, '4.0.1');
+        const results: boolean = authZHandler.isAuthorized({
+            accessToken: practitionerAccessToken,
+            operation: 'read',
+            exportType: 'system',
+        });
+        expect(results).toEqual(false);
+    });
+
+    test('FALSE; GET system Export with permission to CREATE all resources but not READ them', async () => {
+        customRBACRules.groupRules.practitioner.resources = SUPPORTED_R4_RESOURCES;
+        customRBACRules.groupRules.practitioner.operations = ['create'];
         const authZHandler: RBACHandler = new RBACHandler(customRBACRules, '4.0.1');
         const results: boolean = authZHandler.isAuthorized({
             accessToken: practitionerAccessToken,

--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -50,7 +50,7 @@ const nonPractAndAuditorAccessToken: string =
 const practitionerAccessToken: string =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWtlIiwiY29nbml0bzpncm91cHMiOlsicHJhY3RpdGlvbmVyIl0sIm5hbWUiOiJub3QgcmVhbCIsImlhdCI6MTUxNjIzOTAyMn0.bhZZ2O8Vph5aiPfs1n34Enw0075Tt4Cnk2FL2C3mHaQ';
 describe('isAuthorized', () => {
-    const authZHandler: RBACHandler = new RBACHandler(RBACRules);
+    const authZHandler: RBACHandler = new RBACHandler(RBACRules, '4.0.1');
 
     test('TRUE; read direct patient; practitioner', async () => {
         const results: boolean = authZHandler.isAuthorized({
@@ -175,16 +175,19 @@ describe('isAuthorized', () => {
     test('ERROR: Attempt to create a handler to support a new config version', async () => {
         expect(() => {
             // eslint-disable-next-line no-new
-            new RBACHandler({
-                version: 2.0,
-                groupRules: {},
-            });
+            new RBACHandler(
+                {
+                    version: 2.0,
+                    groupRules: {},
+                },
+                '4.0.1',
+            );
         }).toThrow(new Error('Configuration version does not match handler version'));
     });
 });
 
 describe('isBundleRequestAuthorized', () => {
-    const authZHandler: RBACHandler = new RBACHandler(RBACRules);
+    const authZHandler: RBACHandler = new RBACHandler(RBACRules, '4.0.1');
 
     test('TRUE; create direct patient in bundle; practitioner', async () => {
         const results: boolean = await authZHandler.isBundleRequestAuthorized({

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -65,7 +65,7 @@ export class RBACHandler implements Authorization {
 
     private isAllowed(
         groups: string[],
-        operation: TypeOperation | SystemOperation | 'export',
+        operation: TypeOperation | SystemOperation,
         resourceType?: string,
         exportType?: ExportType,
     ): boolean {

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -10,12 +10,14 @@ import {
     TypeOperation,
     SystemOperation,
     BatchReadWriteRequest,
-    SUPPORTED_R4_RESOURCES,
-    SUPPORTED_STU3_RESOURCES,
+    BASE_R4_RESOURCES,
+    BASE_STU3_RESOURCES,
     FhirVersion,
-    PATIENT_COMPARTMENT_RESOURCES,
+    R4_PATIENT_COMPARTMENT_RESOURCES,
+    STU3_PATIENT_COMPARTMENT_RESOURCES,
     R4Resource,
     ExportType,
+    STU3Resource,
 } from 'fhir-works-on-aws-interface';
 
 import isEqual from 'lodash/isEqual';
@@ -57,17 +59,23 @@ export class RBACHandler implements Authorization {
                     if (exportType === 'system') {
                         if (
                             (this.fhirVersion === '4.0.1' &&
-                                isEqual(rule.resources.sort(), SUPPORTED_R4_RESOURCES.sort())) ||
-                            (this.fhirVersion === '3.0.1' &&
-                                isEqual(rule.resources.sort(), SUPPORTED_STU3_RESOURCES.sort()))
+                                isEqual(rule.resources.sort(), BASE_R4_RESOURCES.sort())) ||
+                            (this.fhirVersion === '3.0.1' && isEqual(rule.resources.sort(), BASE_STU3_RESOURCES.sort()))
                         ) {
                             return true;
                         }
                     }
                     if (exportType === 'group' || exportType === 'patient') {
-                        return rule.resources.every(resource => {
-                            return PATIENT_COMPARTMENT_RESOURCES.includes(<R4Resource>resource);
-                        });
+                        if (this.fhirVersion === '4.0.1') {
+                            return R4_PATIENT_COMPARTMENT_RESOURCES.every(resource => {
+                                return rule.resources.includes(resource);
+                            });
+                        }
+                        if (this.fhirVersion === '3.0.1') {
+                            return STU3_PATIENT_COMPARTMENT_RESOURCES.every(resource => {
+                                return rule.resources.includes(resource);
+                            });
+                        }
                     }
                 }
             }

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -15,9 +15,7 @@ import {
     FhirVersion,
     R4_PATIENT_COMPARTMENT_RESOURCES,
     STU3_PATIENT_COMPARTMENT_RESOURCES,
-    R4Resource,
     ExportType,
-    STU3Resource,
 } from 'fhir-works-on-aws-interface';
 
 import isEqual from 'lodash/isEqual';

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -53,7 +53,7 @@ export class RBACHandler implements Authorization {
             const group: string = groups[index];
             if (this.rules.groupRules[group]) {
                 const rule: Rule = this.rules.groupRules[group];
-                if (exportType) {
+                if (exportType && rule.operations.includes('read')) {
                     if (exportType === 'system') {
                         if (
                             (this.fhirVersion === '4.0.1' &&

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -55,6 +55,8 @@ export class RBACHandler implements Authorization {
                 const rule: Rule = this.rules.groupRules[group];
                 if (exportType && rule.operations.includes('read')) {
                     if (exportType === 'system') {
+                        // TODO: Enable supporting of different profiles by specifying the resources you would want to export
+                        // in BASE_R4_RESOURCES
                         if (
                             (this.fhirVersion === '4.0.1' &&
                                 isEqual(rule.resources.sort(), BASE_R4_RESOURCES.sort())) ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -582,6 +582,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-1.19.1.tgz#33509849f8e679e4add158959fdb086440e9553f"
   integrity sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==
 
+"@types/shuffle-array@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@types/shuffle-array/-/shuffle-array-1.0.0.tgz#ac107d83648817e6c811093e5eca7f9eae9f118d"
+  integrity sha512-GEf8V/vpb5OD0OFtGAaOJqMFA2m4MnOQdyc/5ncdudkACxAR0ynOShik/Y2rRcmxdqQIuFMFGB5UjhGDC+dwjA==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -3824,6 +3829,11 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shuffle-array@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/shuffle-array/-/shuffle-array-1.0.1.tgz#c4ff3cfe74d16f93730592301b25e6577b12898b"
+  integrity sha1-xP88/nTRb5NzBZIwGyXmV3sSiYs=
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -557,6 +557,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/lodash@^4.14.161":
+  version "4.14.161"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.161.tgz#a21ca0777dabc6e4f44f3d07f37b765f54188b18"
+  integrity sha512-EP6O3Jkr7bXvZZSZYlsgt5DIjiGr0dXP1/jVEwVLTFgg0d+3lWVQkRavYVQszV7dYUwvg0B8R0MBDpcmXg7XIA==
+
 "@types/node@*":
   version "14.0.25"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.0.25.tgz#7ad8b00a1206d6c9e94810e49f3115f0bcc30456"
@@ -2953,6 +2958,11 @@ lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.20:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
 lolex@^5.0.0:
   version "5.1.2"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added `exportType` as an additional parameter for `isAllowed`. It's an optional parameter with the values of `'system' | 'patient' | 'group'`. This helps us decide how to authorize export requests. 

- [x] Tests added

Related PRs
https://github.com/awslabs/fhir-works-on-aws-interface/pull/13


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.