### PR TITLE
Authorize get-export-status and cancel-export

### DIFF
--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -52,41 +52,15 @@ const RBACRules: RBACConfig = {
         },
     },
 };
-// Decoded JWT
-// {
-//   "sub": "fake",
-//   "username": "FakeUser",
-//   "iat": 1516239022
-// }
+
 const noGroupsAccessToken: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWtlIiwidXNlcm5hbWUiOiJGYWtlVXNlciIsImlhdCI6MTUxNjIzOTAyMn0.v9lkm0coU0t-dUFvBqhV8oMxWG-eU09AupJN4UlfVDI';
-// Decoded JWT
-// {
-//  "sub": "fake",
-//  "cognito:groups": [
-//   "non-practitioner",
-//   "auditor"
-//  ],
-//  "username": "FakeUser",
-//  "iat": 1516239022,
-//  "jti": "f30cd238-5b16-4dcd-8968-332f5d75ddc4",
-//  "exp": 1600023733
-// }
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWtlIiwibmFtZSI6Im5vdCByZWFsIiwiaWF0IjoxNTE2MjM5MDIyfQ.kCA912Pb__JP54WjgZOazu1x8w5KU-kL0iRwQEVFNPw';
+
 const nonPractAndAuditorAccessToken: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWtlIiwiY29nbml0bzpncm91cHMiOlsibm9uLXByYWN0aXRpb25lciIsImF1ZGl0b3IiXSwidXNlcm5hbWUiOiJGYWtlVXNlciIsImlhdCI6MTUxNjIzOTAyMn0._9NJHvjM42dFaVHrzAYPqNfUv0-Qdo6q7vKyvTofdsA';
-// Decoded JWT
-// {
-//  "sub": "fake",
-//  "cognito:groups": [
-//   "practitioner"
-//  ],
-//  "username": "FakeUser",
-//  "iat": 1516239022,
-//  "jti": "2fac726b-6bb0-4bd3-ba00-326c4c9801f4",
-//  "exp": 1600023504
-// }
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWtlIiwiY29nbml0bzpncm91cHMiOlsibm9uLXByYWN0aXRpb25lciIsImF1ZGl0b3IiXSwibmFtZSI6Im5vdCByZWFsIiwiaWF0IjoxNTE2MjM5MDIyfQ.HBNrpqQZPvj43qv1QNFr5u9PoHrtqK4ApsRpN2t7Rz8';
+
 const practitionerAccessToken: string =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWtlIiwiY29nbml0bzpncm91cHMiOlsicHJhY3RpdGlvbmVyIl0sInVzZXJuYW1lIjoiRmFrZVVzZXIiLCJpYXQiOjE1MTYyMzkwMjJ9.XnapGEmAOikHbQ5wyGm7josZszAcNlR1FY0CgsYF8wo';
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWtlIiwiY29nbml0bzpncm91cHMiOlsicHJhY3RpdGlvbmVyIl0sIm5hbWUiOiJub3QgcmVhbCIsImlhdCI6MTUxNjIzOTAyMn0.bhZZ2O8Vph5aiPfs1n34Enw0075Tt4Cnk2FL2C3mHaQ';
 
 describe('isAuthorized', () => {
     const authZHandler: RBACHandler = new RBACHandler(RBACRules, '4.0.1');
@@ -391,7 +365,7 @@ describe('isAuthorized:Export', () => {
             });
         });
 
-        test(`TRUE:${fhirVersion}: Get job status`, () => {
+        test(`TRUE:${fhirVersion}: Get export job status`, () => {
             const authZHandler: RBACHandler = new RBACHandler(
                 getTestPractitionerRBACRules(['read'], BASE_RESOURCES),
                 fhirVersion,
@@ -407,7 +381,7 @@ describe('isAuthorized:Export', () => {
             expect(results).toEqual(true);
         });
 
-        test(`TRUE:${fhirVersion}: Cancel job`, () => {
+        test(`TRUE:${fhirVersion}: Cancel export job`, () => {
             const authZHandler: RBACHandler = new RBACHandler(
                 getTestPractitionerRBACRules(['delete'], BASE_RESOURCES),
                 fhirVersion,

--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -10,6 +10,7 @@ import {
     STU3_PATIENT_COMPARTMENT_RESOURCES,
     FhirVersion,
     BASE_STU3_RESOURCES,
+    AccessBulkDataJobRequest,
 } from 'fhir-works-on-aws-interface';
 import shuffle from 'shuffle-array';
 import each from 'jest-each';
@@ -427,12 +428,20 @@ describe('isAllowedToAccessBulkDataJob', () => {
     const authZHandler: RBACHandler = new RBACHandler(RBACRules, '4.0.1');
 
     test('TRUE: JobOwnerId and requesterUserId matches', () => {
-        const isAllowed = authZHandler.isAllowedToAccessBulkDataJob('userId-1', 'userId-1');
+        const accessBulkDataJobRequest: AccessBulkDataJobRequest = {
+            jobOwnerId: 'userId-1',
+            requesterUserId: 'userId-1',
+        };
+        const isAllowed = authZHandler.isAccessBulkDataJobAllowed(accessBulkDataJobRequest);
         expect(isAllowed).toBeTruthy();
     });
 
     test('FALSE: JobOwnerId and requesterUserId does not match', () => {
-        const isAllowed = authZHandler.isAllowedToAccessBulkDataJob('userId-1', 'userId-2');
+        const accessBulkDataJobRequest: AccessBulkDataJobRequest = {
+            jobOwnerId: 'userId-1',
+            requesterUserId: 'userId-2',
+        };
+        const isAllowed = authZHandler.isAccessBulkDataJobAllowed(accessBulkDataJobRequest);
         expect(isAllowed).toBeFalsy();
     });
 });

--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -270,9 +270,9 @@ describe('isAuthorized:Export', () => {
                 const results: boolean = authZHandler.isAuthorized({
                     accessToken: practitionerAccessToken,
                     operation: 'read',
-                    export: {
+                    bulkDataAuth: {
                         operation: 'initiate-export',
-                        type: 'system',
+                        exportType: 'system',
                     },
                 });
                 expect(results).toEqual(true);
@@ -286,9 +286,9 @@ describe('isAuthorized:Export', () => {
                 const results: boolean = authZHandler.isAuthorized({
                     accessToken: practitionerAccessToken,
                     operation: 'read',
-                    export: {
+                    bulkDataAuth: {
                         operation: 'initiate-export',
-                        type: 'system',
+                        exportType: 'system',
                     },
                 });
                 expect(results).toEqual(true);
@@ -302,9 +302,9 @@ describe('isAuthorized:Export', () => {
                 const results: boolean = authZHandler.isAuthorized({
                     accessToken: practitionerAccessToken,
                     operation: 'read',
-                    export: {
+                    bulkDataAuth: {
                         operation: 'initiate-export',
-                        type: 'system',
+                        exportType: 'system',
                     },
                 });
                 expect(results).toEqual(false);
@@ -318,9 +318,9 @@ describe('isAuthorized:Export', () => {
                 const results: boolean = authZHandler.isAuthorized({
                     accessToken: practitionerAccessToken,
                     operation: 'read',
-                    export: {
+                    bulkDataAuth: {
                         operation: 'initiate-export',
-                        type: 'system',
+                        exportType: 'system',
                     },
                 });
                 expect(results).toEqual(false);
@@ -334,9 +334,9 @@ describe('isAuthorized:Export', () => {
                 const results: boolean = authZHandler.isAuthorized({
                     accessToken: practitionerAccessToken,
                     operation: 'read',
-                    export: {
+                    bulkDataAuth: {
                         operation: 'initiate-export',
-                        type: 'patient',
+                        exportType: 'patient',
                     },
                 });
                 expect(results).toEqual(true);
@@ -350,9 +350,9 @@ describe('isAuthorized:Export', () => {
                 const results: boolean = authZHandler.isAuthorized({
                     accessToken: practitionerAccessToken,
                     operation: 'read',
-                    export: {
+                    bulkDataAuth: {
                         operation: 'initiate-export',
-                        type: 'patient',
+                        exportType: 'patient',
                     },
                 });
                 expect(results).toEqual(false);
@@ -366,9 +366,9 @@ describe('isAuthorized:Export', () => {
                 const results: boolean = authZHandler.isAuthorized({
                     accessToken: practitionerAccessToken,
                     operation: 'read',
-                    export: {
+                    bulkDataAuth: {
                         operation: 'initiate-export',
-                        type: 'group',
+                        exportType: 'group',
                     },
                 });
                 expect(results).toEqual(true);
@@ -382,82 +382,45 @@ describe('isAuthorized:Export', () => {
                 const results: boolean = authZHandler.isAuthorized({
                     accessToken: practitionerAccessToken,
                     operation: 'read',
-                    export: {
+                    bulkDataAuth: {
                         operation: 'initiate-export',
-                        type: 'group',
+                        exportType: 'group',
                     },
                 });
                 expect(results).toEqual(false);
             });
         });
 
-        describe('get-status', () => {
-            test(`TRUE:${fhirVersion}: Get job status`, () => {
-                const authZHandler: RBACHandler = new RBACHandler(
-                    getTestPractitionerRBACRules(['read'], BASE_RESOURCES),
-                    fhirVersion,
-                );
-                const results: boolean = authZHandler.isAuthorized({
-                    accessToken: practitionerAccessToken,
-                    operation: 'read',
-                    export: {
-                        operation: 'get-status',
-                        jobRequesterUserId: 'FakeUser',
-                        type: 'system',
-                    },
-                });
-                expect(results).toEqual(true);
+        test(`TRUE:${fhirVersion}: Get job status`, () => {
+            const authZHandler: RBACHandler = new RBACHandler(
+                getTestPractitionerRBACRules(['read'], BASE_RESOURCES),
+                fhirVersion,
+            );
+            const results: boolean = authZHandler.isAuthorized({
+                accessToken: practitionerAccessToken,
+                operation: 'read',
+                bulkDataAuth: {
+                    operation: 'get-status-export',
+                    exportType: 'system',
+                },
             });
-            test(`FALSE:${fhirVersion}: Get job status`, () => {
-                const authZHandler: RBACHandler = new RBACHandler(
-                    getTestPractitionerRBACRules(['read'], BASE_RESOURCES),
-                    fhirVersion,
-                );
-                const results: boolean = authZHandler.isAuthorized({
-                    accessToken: practitionerAccessToken,
-                    operation: 'read',
-                    export: {
-                        operation: 'get-status',
-                        jobRequesterUserId: 'RandomUser',
-                        type: 'system',
-                    },
-                });
-                expect(results).toEqual(false);
-            });
+            expect(results).toEqual(true);
         });
-        describe('cancel-export', () => {
-            test(`TRUE:${fhirVersion}: Cancel job`, () => {
-                const authZHandler: RBACHandler = new RBACHandler(
-                    getTestPractitionerRBACRules(['delete'], BASE_RESOURCES),
-                    fhirVersion,
-                );
-                const results: boolean = authZHandler.isAuthorized({
-                    accessToken: practitionerAccessToken,
-                    operation: 'delete',
-                    export: {
-                        operation: 'cancel-export',
-                        jobRequesterUserId: 'FakeUser',
-                        type: 'system',
-                    },
-                });
-                expect(results).toEqual(true);
+
+        test(`TRUE:${fhirVersion}: Cancel job`, () => {
+            const authZHandler: RBACHandler = new RBACHandler(
+                getTestPractitionerRBACRules(['delete'], BASE_RESOURCES),
+                fhirVersion,
+            );
+            const results: boolean = authZHandler.isAuthorized({
+                accessToken: practitionerAccessToken,
+                operation: 'delete',
+                bulkDataAuth: {
+                    operation: 'cancel-export',
+                    exportType: 'system',
+                },
             });
-            test(`FALSE:${fhirVersion}: Cancel job`, () => {
-                const authZHandler: RBACHandler = new RBACHandler(
-                    getTestPractitionerRBACRules(['delete'], BASE_RESOURCES),
-                    fhirVersion,
-                );
-                const results: boolean = authZHandler.isAuthorized({
-                    accessToken: practitionerAccessToken,
-                    operation: 'delete',
-                    export: {
-                        operation: 'cancel-export',
-                        jobRequesterUserId: 'RandomUser',
-                        type: 'system',
-                    },
-                });
-                expect(results).toEqual(false);
-            });
+            expect(results).toEqual(true);
         });
     });
 });

--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -210,26 +210,6 @@ describe('isAuthorized:Export', () => {
         },
     });
 
-    // const getBaseResource = (fhirVersion: string) => {
-    //     return fhirVersion === '3.0.1' ? BASE_STU3_RESOURCES : BASE_R4_RESOURCES;
-    // };
-    //
-    // each(['3.0.1', '4.0.1']).test('TRUE:%s: GET system Export with permission to all resources', fhirVersion => {
-    //     const authZHandler: RBACHandler = new RBACHandler(
-    //         getTestPractitionerRBACRules(['read'], getBaseResource(fhirVersion)),
-    //         fhirVersion,
-    //     );
-    //     const results: boolean = authZHandler.isAuthorized({
-    //         accessToken: practitionerAccessToken,
-    //         operation: 'read',
-    //         export: {
-    //             operation: 'initiate-export',
-    //             type: 'system',
-    //         },
-    //     });
-    //     expect(results).toEqual(true);
-    // });
-
     const fhirVersions: FhirVersion[] = ['3.0.1', '4.0.1'];
     fhirVersions.forEach((fhirVersion: FhirVersion) => {
         const BASE_RESOURCES = fhirVersion === '3.0.1' ? BASE_STU3_RESOURCES : BASE_R4_RESOURCES;
@@ -440,5 +420,19 @@ describe('isBundleRequestAuthorized', () => {
             ],
         });
         expect(results).toEqual(false);
+    });
+});
+
+describe('isAllowedToAccessBulkDataJob', () => {
+    const authZHandler: RBACHandler = new RBACHandler(RBACRules, '4.0.1');
+
+    test('TRUE: JobOwnerId and requesterUserId matches', () => {
+        const isAllowed = authZHandler.isAllowedToAccessBulkDataJob('userId-1', 'userId-1');
+        expect(isAllowed).toBeTruthy();
+    });
+
+    test('FALSE: JobOwnerId and requesterUserId does not match', () => {
+        const isAllowed = authZHandler.isAllowedToAccessBulkDataJob('userId-1', 'userId-2');
+        expect(isAllowed).toBeFalsy();
     });
 });

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -48,11 +48,14 @@ export class RBACHandler implements Authorization {
         return this.isAllowed(groups, request.operation, request.resourceType);
     }
 
+    // eslint-disable-next-line class-methods-use-this
+    isAllowedToAccessBulkDataJob(requesterId: string, jobOwnerId: string): boolean {
+        return requesterId === jobOwnerId;
+    }
+
     private isBulkDataAccessAllowed(groups: string[], bulkDataAuth: BulkDataAuth): boolean {
         const { operation, exportType } = bulkDataAuth;
         if (['get-status-export', 'cancel-export', 'get-status-import', 'cancel-import'].includes(operation)) {
-            // The persistence layer has access to the jobId and requesterUserId and will check whether
-            // the user has access to the job
             return true;
         }
         if (operation === 'initiate-export') {

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -16,6 +16,7 @@ import {
     R4_PATIENT_COMPARTMENT_RESOURCES,
     STU3_PATIENT_COMPARTMENT_RESOURCES,
     BulkDataAuth,
+    AccessBulkDataJobRequest,
 } from 'fhir-works-on-aws-interface';
 
 import isEqual from 'lodash/isEqual';
@@ -49,8 +50,8 @@ export class RBACHandler implements Authorization {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    isAllowedToAccessBulkDataJob(requesterId: string, jobOwnerId: string): boolean {
-        return requesterId === jobOwnerId;
+    isAccessBulkDataJobAllowed(request: AccessBulkDataJobRequest): boolean {
+        return request.requesterUserId === request.jobOwnerId;
     }
 
     private isBulkDataAccessAllowed(groups: string[], bulkDataAuth: BulkDataAuth): boolean {

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -15,8 +15,7 @@ import {
     FhirVersion,
     R4_PATIENT_COMPARTMENT_RESOURCES,
     STU3_PATIENT_COMPARTMENT_RESOURCES,
-    ExportType,
-    ExportAuth,
+    BulkDataAuth,
 } from 'fhir-works-on-aws-interface';
 
 import isEqual from 'lodash/isEqual';
@@ -43,49 +42,56 @@ export class RBACHandler implements Authorization {
         const decoded = decode(request.accessToken, { json: true }) || {};
         const groups: string[] = decoded['cognito:groups'] || [];
 
-        if (request.export) {
-            const requesterUserId = this.getRequesterUserId(request.accessToken);
-            return this.isExportAllowed(groups, requesterUserId, request.export);
+        if (request.bulkDataAuth) {
+            return this.isBulkDataAccessAllowed(groups, request.bulkDataAuth);
         }
         return this.isAllowed(groups, request.operation, request.resourceType);
     }
 
-    private isExportAllowed(groups: string[], requesterUserId: string, exportAuth: ExportAuth): boolean {
-        const { jobRequesterUserId, operation, type } = exportAuth;
-        if (['get-status', 'cancel-export'].includes(operation)) {
-            return requesterUserId === jobRequesterUserId;
+    private isBulkDataAccessAllowed(groups: string[], bulkDataAuth: BulkDataAuth): boolean {
+        const { operation, exportType } = bulkDataAuth;
+        if (['get-status-export', 'cancel-export', 'get-status-import', 'cancel-import'].includes(operation)) {
+            // The persistence layer has access to the jobId and requesterUserId and will check whether
+            // the user has access to the job
+            return true;
         }
-        for (let index = 0; index < groups.length; index += 1) {
-            const group: string = groups[index];
-            if (this.rules.groupRules[group]) {
-                const rule: Rule = this.rules.groupRules[group];
-                if (type && rule.operations.includes('read')) {
-                    if (type === 'system') {
-                        // TODO: Enable supporting of different profiles by specifying the resources you would want to export
-                        // in BASE_R4_RESOURCES
-                        if (
-                            (this.fhirVersion === '4.0.1' &&
-                                isEqual(rule.resources.sort(), BASE_R4_RESOURCES.sort())) ||
-                            (this.fhirVersion === '3.0.1' && isEqual(rule.resources.sort(), BASE_STU3_RESOURCES.sort()))
-                        ) {
-                            return true;
+        if (operation === 'initiate-export') {
+            for (let index = 0; index < groups.length; index += 1) {
+                const group: string = groups[index];
+                if (this.rules.groupRules[group]) {
+                    const rule: Rule = this.rules.groupRules[group];
+                    if (exportType && rule.operations.includes('read')) {
+                        if (exportType === 'system') {
+                            // TODO: Enable supporting of different profiles by specifying the resources you would want to export
+                            // in BASE_R4_RESOURCES
+                            if (
+                                (this.fhirVersion === '4.0.1' &&
+                                    isEqual(rule.resources.sort(), BASE_R4_RESOURCES.sort())) ||
+                                (this.fhirVersion === '3.0.1' &&
+                                    isEqual(rule.resources.sort(), BASE_STU3_RESOURCES.sort()))
+                            ) {
+                                return true;
+                            }
                         }
-                    }
-                    if (type === 'group' || type === 'patient') {
-                        if (this.fhirVersion === '4.0.1') {
-                            return R4_PATIENT_COMPARTMENT_RESOURCES.every(resource => {
-                                return rule.resources.includes(resource);
-                            });
-                        }
-                        if (this.fhirVersion === '3.0.1') {
-                            return STU3_PATIENT_COMPARTMENT_RESOURCES.every(resource => {
-                                return rule.resources.includes(resource);
-                            });
+                        if (exportType === 'group' || exportType === 'patient') {
+                            if (this.fhirVersion === '4.0.1') {
+                                return R4_PATIENT_COMPARTMENT_RESOURCES.every(resource => {
+                                    return rule.resources.includes(resource);
+                                });
+                            }
+                            if (this.fhirVersion === '3.0.1') {
+                                return STU3_PATIENT_COMPARTMENT_RESOURCES.every(resource => {
+                                    return rule.resources.includes(resource);
+                                });
+                            }
                         }
                     }
                 }
             }
+        } else if (operation === 'initiate-import') {
+            // TODO Handle `initiate-import` auth
         }
+
         return false;
     }
 


### PR DESCRIPTION
Description of changes:
There are three types of export requests.
1. InitiateExportRequest
2. Get export status
3. Cancel export

Authorizing types two and three is different from type one, because we need to verify that the current user calling this API is the same as the user who created the job. That information is available on the persistence layer, so we will pass that request to the persistence layer. The persistence layer then throw a `UnathorizedAccessError` if it determines that the `requesterUserId` doesn't match with the job's `requesterUserId`.

To authorize type one, we will need to validate if the current user calling this API has read access to the appropriate resources. 

** Related PRs**
* https://github.com/awslabs/fhir-works-on-aws-routing/pull/9
* https://github.com/awslabs/fhir-works-on-aws-interface/pull/14
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.