### PR TITLE
feat: Implement getAllowedResourceTypesForOperation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [1.0.0] - 2020-08-31
 
+- Implement `getAllowedResourceTypesForOperation`
+
+## [1.0.0] - 2020-08-31
+
 ### Added
 
 - Initial launch! :rocket:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.0.0] - 2020-08-31
+## [1.1.0] - 2020-09-25
 
 - Implement `getAllowedResourceTypesForOperation`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.1.0] - 2020-09-25
+## [2.0.0] - 2020-09-25
 
-- Implement `getAllowedResourceTypesForOperation`
+- Implement `fhir-works-on-aws-interface` v2.0.0
 
 ## [1.0.0] - 2020-08-31
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-works-on-aws-authz-rbac",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "FHIR Works on AWS role base access control",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fhir-works-on-aws-authz-rbac",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "FHIR Works on AWS role base access control",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
@@ -28,7 +28,7 @@
     "prepublish": "tsc"
   },
   "dependencies": {
-    "fhir-works-on-aws-interface": "^1.0.0",
+    "fhir-works-on-aws-interface": "^2.0.0",
     "jsonwebtoken": "^8.5.1"
   },
   "devDependencies": {

--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -226,3 +226,45 @@ describe('isBundleRequestAuthorized', () => {
         expect(results).toEqual(false);
     });
 });
+
+describe('getAllowedResourceTypesForOperation', () => {
+    test('Single group', async () => {
+        const authZHandler: RBACHandler = new RBACHandler(RBACRules);
+        expect(
+            authZHandler.getAllowedResourceTypesForOperation({
+                accessToken: practitionerAccessToken,
+                operation: 'search-type',
+            }),
+        ).toEqual([...financialResources, 'Patient']);
+    });
+
+    test('No groups', () => {
+        const authZHandler: RBACHandler = new RBACHandler(RBACRules);
+        expect(
+            authZHandler.getAllowedResourceTypesForOperation({
+                accessToken: noGroupsAccessToken,
+                operation: 'search-type',
+            }),
+        ).toEqual([]);
+    });
+
+    test('Multiple groups', () => {
+        const authZHandler: RBACHandler = new RBACHandler(RBACRules);
+        expect(
+            authZHandler.getAllowedResourceTypesForOperation({
+                accessToken: nonPractAndAuditorAccessToken,
+                operation: 'search-type',
+            }),
+        ).toEqual([...financialResources, 'Patient']);
+    });
+
+    test('operation not allowed', () => {
+        const authZHandler: RBACHandler = new RBACHandler(RBACRules);
+        expect(
+            authZHandler.getAllowedResourceTypesForOperation({
+                accessToken: nonPractAndAuditorAccessToken,
+                operation: 'history-instance',
+            }),
+        ).toEqual([]);
+    });
+});

--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -53,7 +53,7 @@ describe('isAuthorized', () => {
     const authZHandler: RBACHandler = new RBACHandler(RBACRules);
 
     test('TRUE; read direct patient; practitioner', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: practitionerAccessToken,
             resourceType: 'Patient',
             operation: 'read',
@@ -62,7 +62,7 @@ describe('isAuthorized', () => {
         expect(results).toEqual(true);
     });
     test('TRUE; create direct patient; practitioner', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: practitionerAccessToken,
             resourceType: 'Patient',
             operation: 'create',
@@ -70,14 +70,14 @@ describe('isAuthorized', () => {
         expect(results).toEqual(true);
     });
     test('TRUE; transaction; practitioner', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: practitionerAccessToken,
             operation: 'transaction',
         });
         expect(results).toEqual(true);
     });
     test('TRUE; update direct patient; practitioner', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: practitionerAccessToken,
             resourceType: 'Patient',
             operation: 'update',
@@ -86,7 +86,7 @@ describe('isAuthorized', () => {
         expect(results).toEqual(true);
     });
     test('TRUE; DELETE patient; practitioner', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: practitionerAccessToken,
             resourceType: 'Patient',
             operation: 'delete',
@@ -96,7 +96,7 @@ describe('isAuthorized', () => {
     });
 
     test('FASLE; patch patient; practitioner', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: practitionerAccessToken,
             resourceType: 'Patient',
             operation: 'patch',
@@ -105,7 +105,7 @@ describe('isAuthorized', () => {
         expect(results).toEqual(false);
     });
     test('TRUE; GET capability statement; no groups', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: 'notReal',
             operation: 'read',
             resourceType: 'metadata',
@@ -113,7 +113,7 @@ describe('isAuthorized', () => {
         expect(results).toEqual(true);
     });
     test('FALSE; GET Patient; no groups', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: noGroupsAccessToken,
             resourceType: 'Patient',
             operation: 'read',
@@ -122,7 +122,7 @@ describe('isAuthorized', () => {
         expect(results).toEqual(false);
     });
     test('FALSE; POST Patient; non-practitioner/auditor', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: nonPractAndAuditorAccessToken,
             resourceType: 'Patient',
             operation: 'create',
@@ -130,7 +130,7 @@ describe('isAuthorized', () => {
         expect(results).toEqual(false);
     });
     test('TRUE; GET Patient; non-practitioner/auditor', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: nonPractAndAuditorAccessToken,
             resourceType: 'Patient',
             operation: 'read',
@@ -139,7 +139,7 @@ describe('isAuthorized', () => {
         expect(results).toEqual(true);
     });
     test('TRUE; Patient Search; non-practitioner/auditor', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: nonPractAndAuditorAccessToken,
             resourceType: 'Patient',
             operation: 'search-type',
@@ -147,14 +147,14 @@ describe('isAuthorized', () => {
         expect(results).toEqual(true);
     });
     test('FALSE; Global Search; non-practitioner/auditor', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: nonPractAndAuditorAccessToken,
             operation: 'search-system',
         });
         expect(results).toEqual(false);
     });
     test('TRUE; GET specific Patient history; non-practitioner/auditor', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: nonPractAndAuditorAccessToken,
             resourceType: 'Patient',
             operation: 'vread',
@@ -164,7 +164,7 @@ describe('isAuthorized', () => {
         expect(results).toEqual(true);
     });
     test('FALSE; GET Patient history; non-practitioner/auditor', async () => {
-        const results: boolean = authZHandler.isAuthorized({
+        const results: boolean = await authZHandler.isAuthorized({
             accessToken: nonPractAndAuditorAccessToken,
             resourceType: 'Patient',
             operation: 'history-type',
@@ -230,41 +230,41 @@ describe('isBundleRequestAuthorized', () => {
 describe('getAllowedResourceTypesForOperation', () => {
     test('Single group', async () => {
         const authZHandler: RBACHandler = new RBACHandler(RBACRules);
-        expect(
+        await expect(
             authZHandler.getAllowedResourceTypesForOperation({
                 accessToken: practitionerAccessToken,
                 operation: 'search-type',
             }),
-        ).toEqual([...financialResources, 'Patient']);
+        ).resolves.toEqual([...financialResources, 'Patient']);
     });
 
-    test('No groups', () => {
+    test('No groups', async () => {
         const authZHandler: RBACHandler = new RBACHandler(RBACRules);
-        expect(
+        await expect(
             authZHandler.getAllowedResourceTypesForOperation({
                 accessToken: noGroupsAccessToken,
                 operation: 'search-type',
             }),
-        ).toEqual([]);
+        ).resolves.toEqual([]);
     });
 
-    test('Multiple groups', () => {
+    test('Multiple groups', async () => {
         const authZHandler: RBACHandler = new RBACHandler(RBACRules);
-        expect(
+        await expect(
             authZHandler.getAllowedResourceTypesForOperation({
                 accessToken: nonPractAndAuditorAccessToken,
                 operation: 'search-type',
             }),
-        ).toEqual([...financialResources, 'Patient']);
+        ).resolves.toEqual([...financialResources, 'Patient']);
     });
 
-    test('operation not allowed', () => {
+    test('operation not allowed', async () => {
         const authZHandler: RBACHandler = new RBACHandler(RBACRules);
-        expect(
+        await expect(
             authZHandler.getAllowedResourceTypesForOperation({
                 accessToken: nonPractAndAuditorAccessToken,
                 operation: 'history-instance',
             }),
-        ).toEqual([]);
+        ).resolves.toEqual([]);
     });
 });

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -10,6 +10,7 @@ import {
     TypeOperation,
     SystemOperation,
     BatchReadWriteRequest,
+    getAllowedResourceTypesForOperationRequest,
 } from 'fhir-works-on-aws-interface';
 import { Rule, RBACConfig } from './RBACConfig';
 
@@ -43,6 +44,20 @@ export class RBACHandler implements Authorization {
         });
         const authZResponses: boolean[] = await Promise.all(authZPromises);
         return authZResponses.every(Boolean);
+    }
+
+    getAllowedResourceTypesForOperation(request: getAllowedResourceTypesForOperationRequest): string[] {
+        const { accessToken, operation } = request;
+        const decoded = decode(accessToken, { json: true }) || {};
+        const groups: string[] = decoded['cognito:groups'] || [];
+
+        return groups.flatMap(group => {
+            const groupRule = this.rules.groupRules[group];
+            if (groupRule !== undefined && groupRule.operations.includes(operation)) {
+                return groupRule.resources;
+            }
+            return [];
+        });
     }
 
     private isAllowed(groups: string[], operation: TypeOperation | SystemOperation, resourceType?: string): boolean {

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -10,7 +10,7 @@ import {
     TypeOperation,
     SystemOperation,
     BatchReadWriteRequest,
-    getAllowedResourceTypesForOperationRequest,
+    AllowedResourceTypesForOperationRequest,
 } from 'fhir-works-on-aws-interface';
 import { Rule, RBACConfig } from './RBACConfig';
 
@@ -27,7 +27,7 @@ export class RBACHandler implements Authorization {
         }
     }
 
-    isAuthorized(request: AuthorizationRequest): boolean {
+    async isAuthorized(request: AuthorizationRequest): Promise<boolean> {
         const decoded = decode(request.accessToken, { json: true }) || {};
         const groups: string[] = decoded['cognito:groups'] || [];
 
@@ -46,7 +46,7 @@ export class RBACHandler implements Authorization {
         return authZResponses.every(Boolean);
     }
 
-    getAllowedResourceTypesForOperation(request: getAllowedResourceTypesForOperationRequest): string[] {
+    async getAllowedResourceTypesForOperation(request: AllowedResourceTypesForOperationRequest): Promise<string[]> {
         const { accessToken, operation } = request;
         const decoded = decode(accessToken, { json: true }) || {};
         const groups: string[] = decoded['cognito:groups'] || [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,10 +1709,10 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fhir-works-on-aws-interface@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-1.0.0.tgz#7de73929ebab013745582518f7596607c85a4ad0"
-  integrity sha512-b+B7D4/Msfzku/efM7dhbqCANEjCEKqUm7YJwEsQVjfmNbyRHWNmk+Mer89POmPnbw0eqryjnvV7C698C/8+rQ==
+fhir-works-on-aws-interface@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/fhir-works-on-aws-interface/-/fhir-works-on-aws-interface-2.0.0.tgz#98c04208c32653f9d75743663c036f1d6eae6ffb"
+  integrity sha512-hdjZJaNEoSYXYVEDOtCQW/HxnQhnF2Nu02nzgeNEWdsZN8MiMakmLX/JxnPYmG13/L9J69CpeV1PmZCsT9HG3g==
 
 figures@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
Description of changes:

Implement new interface method described in https://github.com/awslabs/fhir-works-on-aws-interface/pull/16

Note: Need to publish the updated interface to npm first. Until then, checks are failing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.