### PR TITLE
fix: For auth use 'sub' to uniquely identify user instead of username

### DIFF
--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -486,3 +486,18 @@ describe('isAllowedToAccessBulkDataJob', () => {
         expect(isAllowed).toBeFalsy();
     });
 });
+
+describe('getRequesterUserId', () => {
+    // Decoded Access Token
+    // {
+    //     "sub": "fakeSub1",
+    //     "username": "FakeUser",
+    //     "iat": 1516239022
+    // }
+    const accessToken =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJmYWtlU3ViMSIsInVzZXJuYW1lIjoiRmFrZVVzZXIiLCJpYXQiOjE1MTYyMzkwMjJ9.QYnnbabXcPCa5fqr5Fymr2xuC0aJtkPHXxNqta0PT8U';
+    const authZHandler: RBACHandler = new RBACHandler(RBACRules, '4.0.1');
+    test('getRequestUserId matches access token sub', () => {
+        expect(authZHandler.getRequesterUserId(accessToken)).toEqual('fakeSub1');
+    });
+});

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -129,7 +129,7 @@ export class RBACHandler implements Authorization {
     // eslint-disable-next-line class-methods-use-this
     getRequesterUserId(accessToken: string): string {
         const decoded = decode(accessToken, { json: true }) || {};
-        return decoded.username;
+        return decoded.sub;
     }
 
     private isAllowed(groups: string[], operation: TypeOperation | SystemOperation, resourceType?: string): boolean {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
fix: For auth use 'sub' to uniquely identify user instead of username

Manually tested by making an export request to initiate an export. Checked that DDB showed the `sub` value for `jobOwnerId`. Also confirmed that when making a request for `jobStatus`, the code used `sub` to check for the right user.

[Context for using sub instead of username](https://stackoverflow.com/questions/39223347/should-i-use-aws-cognito-username-or-sub-uid-for-storing-in-database#:~:text=A%20username%20is%20always%20required,after%20a%20user%20is%20created.&text=The%20username%20must%20be%20unique,is%20no%20longer%20in%20use)
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.