### PR TITLE
chore: We no longer require Auth for metadata route

### DIFF
--- a/src/RBACHandler.test.ts
+++ b/src/RBACHandler.test.ts
@@ -145,15 +145,6 @@ describe('verifyAccessToken', () => {
             }),
         ).rejects.toThrowError(UnauthorizedError);
     });
-    test('GET capability statement with no groups; expected: pass', async () => {
-        await expect(
-            authZHandler.verifyAccessToken({
-                accessToken: 'notReal',
-                operation: 'read',
-                resourceType: 'metadata',
-            }),
-        ).resolves.toEqual({});
-    });
     test('GET Patient with no groups; expected: UnauthorizedError', async () => {
         await expect(
             authZHandler.verifyAccessToken({

--- a/src/RBACHandler.ts
+++ b/src/RBACHandler.ts
@@ -97,9 +97,6 @@ export class RBACHandler implements Authorization {
     async isWriteRequestAuthorized(_request: WriteRequestAuthorizedRequest): Promise<void> {}
 
     private isAllowed(groups: string[], operation: TypeOperation | SystemOperation, resourceType?: string): void {
-        if (operation === 'read' && resourceType === 'metadata') {
-            return; // capabilities statement
-        }
         for (let index = 0; index < groups.length; index += 1) {
             const group: string = groups[index];
             if (this.rules.groupRules[group]) {


### PR DESCRIPTION
Description of changes:
chore: We no longer require Auth for metadata route, because router authorize requests after `metdata` route is set up.

related PR: https://github.com/awslabs/fhir-works-on-aws-routing/pull/28
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.